### PR TITLE
update: Add specific 'compile' target

### DIFF
--- a/ambu
+++ b/ambu
@@ -9,11 +9,17 @@ PROJECTNAME=$PROJECT".ino"
 
 usage() {
     echo "usage: $0 target [project-dir]"
+    echo "  (Note that there exists a special target 'compile' which just compiles"
+    echo "   the code, which is what a bare 'make' would do with Arduino Makefile)"
 }
 
 if [ -z "$1" ]; then
     usage
     exit 0
+fi
+
+if [ "$MAKEMODE" == "compile" ]; then
+    MAKEMODE=''
 fi
 
 if [ ! -d "$CURRENTDIR" ]; then


### PR DESCRIPTION
- ambu definitely needs a way of just compiling and not trying to upload
  it anywhere (so that it can be used in some rudimentary tests for
  instance). Arduino Makefile does so by not providing a specific
  target.
  
  This commit therefore adds a target 'compile' which is then replaced
  by essentially 'no target' and correctly provided as an argument to
  Arduino Makefile.

Signed-off-by: mr.Shu mr@shu.io
