### PR TITLE
fix: fixed bash function declaration

### DIFF
--- a/ambu
+++ b/ambu
@@ -7,7 +7,7 @@ PARENTDIR=`dirname $CURRENTDIR`
 BUILDDIR=$PARENTDIR/".build_"$PROJECT
 PROJECTNAME=$PROJECT".ino"
 
-usage() {
+function usage() {
     echo "usage: $0 target [project-dir]"
     echo "  (Note that there exists a special target 'compile' which just compiles"
     echo "   the code, which is what a bare 'make' would do with Arduino Makefile)"


### PR DESCRIPTION
- some bashes does not support declaring function
  without `function` keyword

Signed-off-by: Adrian Matejov a.matejov@centrum.sk
